### PR TITLE
Version 3.2

### DIFF
--- a/sIRCOperFIlterv3.pl
+++ b/sIRCOperFIlterv3.pl
@@ -29,7 +29,8 @@
 ##     -Removed 'SilverIRC' from        ##
 ##      description                     ##
 ##     -Removed some whitespace from    ##
-##      the notices
+##      the notices                     ##
+##     -Removed colons from notices     ##
 ##########################################
 
 $SCRIPTNAME = "Oper-Filter";

--- a/sIRCOperFIlterv3.pl
+++ b/sIRCOperFIlterv3.pl
@@ -1,9 +1,5 @@
 ##########################################
-##         IRCop Filter Script          ##
-##              for XChat               ##
-##                                      ##
-##           Created for the            ##
-##            SilverIRC OPs             ##
+##    IRCop Filter Script for HexChat   ##
 ##                                      ##
 ##          (c)2010 KittyKatt           ##
 ##########################################
@@ -28,111 +24,110 @@
 ##      "Announce" and all "Remote*"    ##
 ##      into "*(R)"                     ##
 ##                                      ##
+##           Revision (v3.2)            ##
+##     -Changed XChat to HexChat        ##
+##     -Removed 'SilverIRC' from        ##
+##      description                     ##
+##     -Removed some whitespace from    ##
+##      the notices
 ##########################################
 
-$SCRIPTNAME = "SilverIRC Oper-Filter";
-$VERSION = "3.1";
- 
-Xchat::register($SCRIPTNAME,$VERSION,"SilverIRC IRCop Script to filter the (snotices) tab.",);
-Xchat::hook_print("Server Notice", \&filter_snotice); # Hooks on all Server Notices
+$SCRIPTNAME = "Oper-Filter";
+$VERSION = "3.2";
+$DESCRIPTION = "IRCop Script to filter the snotices tab";
+
+HexChat::register($SCRIPTNAME,$VERSION,$DESCRIPTION);
+HexChat::hook_print("Server Notice", \&filter_snotice); # Hooks on all Server Notices
 
 sub filter_snotice {
 	my $line = $_[0][0];
-	my $servername = Xchat::get_info("server");
+	my $servername = HexChat::get_info("server");
 	if ($line =~ m/REMOTECONNECT/) {
 		$line =~ s/^\*\*\* REMOTECONNECT: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC18 Connect (R) \cC30]\cC18:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC18Connect (R)\cC30]\cC18:\cC30", $line);
 		return 1;
 	} elsif ($line =~ m/CONNECT/) {
 		$line =~ s/^\*\*\* CONNECT: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC18 Connect \cC30]\cC18:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC18Connect\cC30]\cC18:\cC30", $line);
 		return 1;
 	} elsif ($line =~ m/REMOTEQUIT/) {
 		$line =~ s/^\*\*\* REMOTEQUIT: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC29 Disconnect (R) \cC30]\cC29:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC29Disconnect (R)\cC30]\cC29:\cC30", $line);
 		return 1;
 	} elsif ($line =~ m/QUIT/) {
 		$line =~ s/^\*\*\* QUIT: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC29 Disconnect \cC30]\cC29:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC29Disconnect\cC30]\cC29:\cC30", $line);
 		return 1;
 	} elsif ($line =~ m/REMOTEKILL/) {
 		$line =~ s/^\*\*\* REMOTEKILL: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC18 Kill (R) \cC30]\cC18:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC18Kill (R)\cC30]\cC18:\cC30", $line);
 		return 1;
 	} elsif ($line =~ m/KILL/) {
 		$line =~ s/^\*\*\* KILL: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC18 Kill \cC30]\cC18:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC18Kill\cC30]\cC18:\cC30", $line);
 		return 1;
 	} elsif ($line =~ m/DEBUG/) {
 		$line =~ s/^\*\*\* DEBUG: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC20 Debug \cC30]\cC20:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC20Debug\cC30]\cC20:\cC30", $line);
 		return 1;
 	} elsif ($line =~ m/REMOTELINK/) {
 		$line =~ s/^\*\*\* REMOTELINK: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC19 Link (R) \cC30]\cC19:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC19Link (R)\cC30]\cC19:\cC30", $line);
 		return 1;
 	} elsif ($line =~ m/LINK/) {
 		$line =~ s/^\*\*\* LINK: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC19 Link \cC30]\cC19:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC19Link\cC30]\cC19:\cC30", $line);
 		return 1;
 	} elsif ($line =~ m/REMOTEOPER/) {
 		$line =~ s/^\*\*\* REMOTEOPER: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC19 Oper (R) \cC30]\cC19:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC19Oper (R)\cC30]\cC19:\cC30", $line);
 		return 1;
 	} elsif ($line =~ m/OPER/) {
 		$line =~ s/^\*\*\* OPER: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC19 Oper \cC30]\cC19:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC19Oper\cC30]\cC19:\cC30", $line);
 		return 1;
 	} elsif ($line =~ m/REMOTEANNOUNCEMENT/) {
 		$line =~ s/^\*\*\* REMOTEANNOUNCEMENT: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC20 Announce (R) \cC30]\cC20:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC20Announce (R)\cC30]\cC20:\cC30", $line);
 		return 1;
 	} elsif ($line =~ m/ANNOUNCEMENT/) {
 		$line =~ s/^\*\*\* ANNOUNCEMENT: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC20 Announce \cC30]\cC20:\cC30", $line);
-		return 1;
-	} elsif ($line =~ m/REMOTELINK/) {
-		$line =~ s/^\*\*\* REMOTELINK: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC19 Link (R) \cC30]\cC19:\cC30", $line);
-		return 1;
-	} elsif ($line =~ m/REMOTELINK/) {
-		$line =~ s/^\*\*\* REMOTELINK: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC19 Link (R) \cC30]\cC19:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC20Announce\cC30]\cC20:\cC30", $line);
 		return 1;
 	} elsif ($line =~ m/STATS/) {
 		$line =~ s/^\*\*\* STATS: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC20 Stats \cC30]\cC20:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC20Stats\cC30]\cC20:\cC30", $line);
 		return 1;
 	} elsif ($line =~ m/REMOTEGLOBOPS/) {
 		$line =~ s/^\*\*\* REMOTEGLOBOPS: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC23 Global OPs \cC30]\cC23:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC23Global OPs\cC30]\cC23:\cC30", $line);
 		return 1;
 	} elsif ($line =~ m/GLOBOPS/) {
 		$line =~ s/^\*\*\* GLOBOPS: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC23 Global OPs \cC30]\cC23:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC23Global OPs\cC30]\cC23:\cC30", $line);
 		return 1;
 	} elsif ($line =~ m/REMOTECHANCREATE/) {
 		$line =~ s/^\*\*\* REMOTECHANCREATE: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC27 Channel Creation \cC30]\cC27:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC27Channel Creation\cC30]\cC27:\cC30", $line);
 		return 1;
 	} elsif ($line =~ m/CHANCREATE/) {
 		$line =~ s/^\*\*\* CHANCREATE: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC27 Channel Creation \cC30]\cC27:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC27Channel Creation\cC30]\cC27:\cC30", $line);
 		return 1;
 	} elsif ($line =~ m/REMOTENICK/) {
 		$line =~ s/^\*\*\* REMOTENICK: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC27 Nick Change \cC30]\cC27:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC27Nick Change\cC30]\cC27:\cC30", $line);
 		return 1;
 	} elsif ($line =~ m/NICK/) {
 		$line =~ s/^\*\*\* NICK: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC27 Nick Change \cC30]\cC27:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC27Nick Change\cC30]\cC27:\cC30", $line);
 		return 1;
 	} elsif ($line =~ m/XLINE/) {
 		$line =~ s/^\*\*\* XLINE: //;
-		Xchat::emit_print('Generic Message', "\cB\cC30[\cC20 X:Line \cC30]\cC20:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC20X:Line\cC30]\cC20:\cC30", $line);
 		return 1;
 	}
 	return 0;
 }
 
-Xchat::print("\cB\cC26$SCRIPTNAME $VERSION Successfully Loaded.\cO\n");
+HexChat::print("\cB\cC26$SCRIPTNAME $VERSION Successfully Loaded.\cO\n");

--- a/sIRCOperFIlterv3.pl
+++ b/sIRCOperFIlterv3.pl
@@ -44,87 +44,87 @@ sub filter_snotice {
 	my $servername = HexChat::get_info("server");
 	if ($line =~ m/REMOTECONNECT/) {
 		$line =~ s/^\*\*\* REMOTECONNECT: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC18Connect (R)\cC30]\cC18:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC18Connect (R)\cC30]", $line);
 		return 1;
 	} elsif ($line =~ m/CONNECT/) {
 		$line =~ s/^\*\*\* CONNECT: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC18Connect\cC30]\cC18:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC18Connect\cC30]", $line);
 		return 1;
 	} elsif ($line =~ m/REMOTEQUIT/) {
 		$line =~ s/^\*\*\* REMOTEQUIT: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC29Disconnect (R)\cC30]\cC29:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC29Disconnect (R)\cC30]", $line);
 		return 1;
 	} elsif ($line =~ m/QUIT/) {
 		$line =~ s/^\*\*\* QUIT: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC29Disconnect\cC30]\cC29:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC29Disconnect\cC30]", $line);
 		return 1;
 	} elsif ($line =~ m/REMOTEKILL/) {
 		$line =~ s/^\*\*\* REMOTEKILL: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC18Kill (R)\cC30]\cC18:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC18Kill (R)\cC30]", $line);
 		return 1;
 	} elsif ($line =~ m/KILL/) {
 		$line =~ s/^\*\*\* KILL: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC18Kill\cC30]\cC18:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC18Kill\cC30]", $line);
 		return 1;
 	} elsif ($line =~ m/DEBUG/) {
 		$line =~ s/^\*\*\* DEBUG: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC20Debug\cC30]\cC20:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC20Debug\cC30]", $line);
 		return 1;
 	} elsif ($line =~ m/REMOTELINK/) {
 		$line =~ s/^\*\*\* REMOTELINK: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC19Link (R)\cC30]\cC19:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC19Link (R)\cC30]", $line);
 		return 1;
 	} elsif ($line =~ m/LINK/) {
 		$line =~ s/^\*\*\* LINK: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC19Link\cC30]\cC19:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC19Link\cC30]", $line);
 		return 1;
 	} elsif ($line =~ m/REMOTEOPER/) {
 		$line =~ s/^\*\*\* REMOTEOPER: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC19Oper (R)\cC30]\cC19:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC19Oper (R)\cC30]", $line);
 		return 1;
 	} elsif ($line =~ m/OPER/) {
 		$line =~ s/^\*\*\* OPER: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC19Oper\cC30]\cC19:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC19Oper\cC30]", $line);
 		return 1;
 	} elsif ($line =~ m/REMOTEANNOUNCEMENT/) {
 		$line =~ s/^\*\*\* REMOTEANNOUNCEMENT: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC20Announce (R)\cC30]\cC20:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC20Announce (R)", $line);
 		return 1;
 	} elsif ($line =~ m/ANNOUNCEMENT/) {
 		$line =~ s/^\*\*\* ANNOUNCEMENT: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC20Announce\cC30]\cC20:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC20Announce\cC30]", $line);
 		return 1;
 	} elsif ($line =~ m/STATS/) {
 		$line =~ s/^\*\*\* STATS: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC20Stats\cC30]\cC20:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC20Stats\cC30]", $line);
 		return 1;
 	} elsif ($line =~ m/REMOTEGLOBOPS/) {
 		$line =~ s/^\*\*\* REMOTEGLOBOPS: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC23Global OPs\cC30]\cC23:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC23Global OPs\cC30]", $line);
 		return 1;
 	} elsif ($line =~ m/GLOBOPS/) {
 		$line =~ s/^\*\*\* GLOBOPS: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC23Global OPs\cC30]\cC23:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC23Global OPs\cC30]", $line);
 		return 1;
 	} elsif ($line =~ m/REMOTECHANCREATE/) {
 		$line =~ s/^\*\*\* REMOTECHANCREATE: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC27Channel Creation\cC30]\cC27:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC27Channel Creation\cC30]", $line);
 		return 1;
 	} elsif ($line =~ m/CHANCREATE/) {
 		$line =~ s/^\*\*\* CHANCREATE: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC27Channel Creation\cC30]\cC27:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC27Channel Creation\cC30]", $line);
 		return 1;
 	} elsif ($line =~ m/REMOTENICK/) {
 		$line =~ s/^\*\*\* REMOTENICK: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC27Nick Change\cC30]\cC27:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC27Nick Change\cC30]", $line);
 		return 1;
 	} elsif ($line =~ m/NICK/) {
 		$line =~ s/^\*\*\* NICK: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC27Nick Change\cC30]\cC27:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC27Nick Change\cC30]", $line);
 		return 1;
 	} elsif ($line =~ m/XLINE/) {
 		$line =~ s/^\*\*\* XLINE: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC20X:Line\cC30]\cC20:\cC30", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC20X:Line\cC30]", $line);
 		return 1;
 	}
 	return 0;

--- a/sIRCOperFIlterv3.pl
+++ b/sIRCOperFIlterv3.pl
@@ -89,7 +89,7 @@ sub filter_snotice {
 		return 1;
 	} elsif ($line =~ m/REMOTEANNOUNCEMENT/) {
 		$line =~ s/^\*\*\* REMOTEANNOUNCEMENT: //;
-		HexChat::emit_print('Generic Message', "\cB\cC30[\cC20Announce (R)", $line);
+		HexChat::emit_print('Generic Message', "\cB\cC30[\cC20Announce (R)\cC30]", $line);
 		return 1;
 	} elsif ($line =~ m/ANNOUNCEMENT/) {
 		$line =~ s/^\*\*\* ANNOUNCEMENT: //;


### PR DESCRIPTION
Changed xchat to hexchat (people shouldn't use xchat anymore anyway)
Removed 'silverirc' from scriptname

Removed whitespace in notices
`[Disconnect (R)]` instead of `[ Disconnect (R) ]`

Removed superfluous colons from notices (and color codes)
`[Disconnect (R)]` instead of `[Disconnect (R)]:`
